### PR TITLE
Add a new tool gh-watch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /gh-go-rdeps
 /gh-find
 /gh-pr
+/gh-watch

--- a/Makefile
+++ b/Makefile
@@ -12,5 +12,6 @@ build:
 	go build ./cmd/gh-go-rdeps
 	go build ./cmd/gh-pr
 	go build ./cmd/gh-purge-artifacts
+	go build ./cmd/gh-watch
 
 .PHONY: test tests build

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ GitHub productivity tools
 - [gh-go-rdeps](cmd/gh-go-rdeps) Find reverse Go dependencies across GitHub repositories
 - [gh-find](cmd/gh-find) Walk file hierarchies across GitHub repositories
 - [gh-pr](cmd/gh-pr) Automate PR creation across GitHub repositories
+- [gh-watch](cmd/gh-watch) Manage notification subscriptions across GitHub repositories
 
 ## Authentication
 

--- a/cmd/gh-watch/README.md
+++ b/cmd/gh-watch/README.md
@@ -1,0 +1,51 @@
+# gh-watch
+
+Manage notification subscriptions across GitHub repositories.
+
+## Installation
+
+```sh
+cd
+GO111MODULE=on go get github.com/pmatseykanets/gh-tools/cmd/gh-watch@latest
+```
+
+## Usage
+
+```txt
+Usage: gh-watch [flags] [owner][/repo]
+  owner         Repository owner (user or organization)
+  repo          Repository name
+
+Flags:
+  -help         Print this information and exit
+  -no-repo=     The pattern to reject repository names
+  -repo=        The pattern to match repository names
+  -token        Prompt for an Access Token
+  -unwatch      Unsubscribe from repository notifications
+  -version      Print the version and exit
+  -watch        Subscribe to repository notifications
+```
+
+## Environment variables
+
+`GHTOOLS_TOKEN` and `GITHUB_TOKEN` in the order of precedence can be used to set a GitHub access token.
+
+### Examples
+
+List the subscription status for all repositories in the GitHub org `foo`:
+
+```sh
+gh-watch foo
+```
+
+Unsubscribe from all repositories in the GitHub org foo:
+
+```sh
+gh-watch -unwatch foo
+```
+
+Subscribe to notifications for repositories starting with `api-` in the GitHub org foo:
+
+```sh
+gh-watch -watch -repo '$api-' foo
+```

--- a/cmd/gh-watch/main.go
+++ b/cmd/gh-watch/main.go
@@ -1,0 +1,219 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"regexp"
+	"strings"
+
+	"github.com/google/go-github/v32/github"
+	"github.com/pmatseykanets/gh-tools/auth"
+	gh "github.com/pmatseykanets/gh-tools/github"
+	"github.com/pmatseykanets/gh-tools/terminal"
+	"github.com/pmatseykanets/gh-tools/version"
+	"golang.org/x/oauth2"
+)
+
+func usage() {
+	usage := `Manage notification subscriptions across GitHub repositories
+
+Usage: gh-watch [flags] [owner][/repo]
+  owner         Repository owner (user or organization)
+  repo          Repository name
+
+Flags:
+  -help         Print this information and exit
+  -no-repo=     The pattern to reject repository names
+  -repo=        The pattern to match repository names
+  -token        Prompt for an Access Token
+  -unwatch      Unsubscribe from repository notifications
+  -version      Print the version and exit
+  -watch        Subscribe to repository notifications
+`
+	fmt.Println(usage)
+}
+
+func main() {
+	if err := run(context.Background()); err != nil {
+		fmt.Printf("error: %s\n", err)
+		os.Exit(1)
+	}
+}
+
+type config struct {
+	owner        string
+	repo         string
+	repoRegexp   *regexp.Regexp
+	token        bool           // Propmt for an access token.
+	noRepoRegexp *regexp.Regexp // The pattern to reject repository names.
+	watch        bool           // Subscribe to repository notifications.
+	unwatch      bool           // Unsubscribe from repository notifications.
+}
+
+type subscriber struct {
+	gh     *github.Client
+	config config
+	stdout io.WriteCloser
+	stderr io.WriteCloser
+}
+
+func readConfig() (config, error) {
+	if len(os.Args) == 0 {
+		usage()
+		os.Exit(1)
+	}
+
+	config := config{}
+
+	var (
+		showVersion, showHelp bool
+		repo, noRepo          string
+		err                   error
+	)
+	flag.BoolVar(&showHelp, "help", showHelp, "Print this information and exit")
+	flag.StringVar(&noRepo, "no-repo", "", "The pattern to reject repository names")
+	flag.StringVar(&repo, "repo", "", "The pattern to match repository names")
+	flag.BoolVar(&config.token, "token", config.token, "Prompt for Access Token")
+	flag.BoolVar(&config.unwatch, "unwatch", config.unwatch, "Unsubscribe from repository notifications")
+	flag.BoolVar(&showVersion, "version", showVersion, "Print version and exit")
+	flag.BoolVar(&config.watch, "watch", config.watch, "Subscribe to repository notifications")
+
+	flag.Usage = usage
+	flag.Parse()
+
+	if showHelp {
+		usage()
+		os.Exit(0)
+	}
+
+	if showVersion {
+		fmt.Printf("gh-watch version %s\n", version.Version)
+		os.Exit(0)
+	}
+
+	parts := strings.Split(flag.Arg(0), "/")
+	nparts := len(parts)
+	if nparts > 0 {
+		config.owner = parts[0]
+	}
+	if nparts > 1 {
+		config.repo = parts[1]
+	}
+	if nparts > 2 {
+		return config, fmt.Errorf("invalid owner or repository name %s", flag.Arg(0))
+	}
+
+	if config.owner == "" {
+		return config, fmt.Errorf("owner is required")
+	}
+
+	if repo != "" {
+		config.repoRegexp, err = regexp.Compile(repo)
+		if err != nil {
+			return config, fmt.Errorf("invalid name pattern: %s: %s", repo, err)
+		}
+	}
+
+	if noRepo != "" {
+		if config.noRepoRegexp, err = regexp.Compile(noRepo); err != nil {
+			return config, fmt.Errorf("invalid no-repo pattern: %s", err)
+		}
+	}
+
+	return config, nil
+}
+
+func run(ctx context.Context) error {
+	var err error
+
+	subscriber := &subscriber{
+		stdout: os.Stdout,
+		stderr: os.Stderr,
+	}
+	subscriber.config, err = readConfig()
+	if err != nil {
+		return err
+	}
+
+	var token string
+	if subscriber.config.token {
+		token, _ = terminal.PasswordPrompt("Access Token: ")
+	} else {
+		token = auth.GetToken()
+	}
+	if token == "" {
+		return fmt.Errorf("access token is required")
+	}
+
+	subscriber.gh = github.NewClient(oauth2.NewClient(ctx, oauth2.StaticTokenSource(
+		&oauth2.Token{AccessToken: token},
+	)))
+
+	return subscriber.run(ctx)
+}
+
+func subscriptionStatus(sub *github.Subscription) string {
+	if sub == nil {
+		return "not watching"
+	}
+
+	if sub.GetIgnored() {
+		return "ignoring"
+	}
+
+	return "watching"
+}
+
+func (w *subscriber) run(ctx context.Context) error {
+	repos, err := gh.NewRepoFinder(w.gh).Find(ctx, gh.RepoFilter{
+		Owner:      w.config.owner,
+		Repo:       w.config.repo,
+		RepoRegexp: w.config.repoRegexp,
+	})
+	if err != nil {
+		return err
+	}
+
+	for _, repo := range repos {
+		fmt.Fprint(w.stdout, repo.GetFullName())
+
+		// Get the current subscription for the repo.
+		sub, _, err := w.gh.Activity.GetRepositorySubscription(ctx, w.config.owner, repo.GetName())
+		if err != nil {
+			fmt.Fprintln(w.stdout)
+			return err
+		}
+
+		// List the current subscription status.
+		fmt.Fprint(w.stdout, " ", subscriptionStatus(sub))
+
+		switch {
+		case w.config.watch && !sub.GetSubscribed():
+			sub, _, err = w.gh.Activity.SetRepositorySubscription(ctx, w.config.owner, repo.GetName(), &github.Subscription{
+				Subscribed: github.Bool(true),
+			})
+			if err != nil {
+				fmt.Fprintln(w.stdout)
+				return err
+			}
+
+			fmt.Fprint(w.stdout, " -> ", subscriptionStatus(sub))
+		case w.config.unwatch && sub.GetSubscribed():
+			_, err = w.gh.Activity.DeleteRepositorySubscription(ctx, w.config.owner, repo.GetName())
+			if err != nil {
+				fmt.Fprintln(w.stdout)
+				return err
+			}
+			sub = nil
+
+			fmt.Fprint(w.stdout, " -> ", subscriptionStatus(sub))
+		}
+
+		fmt.Fprintln(w.stdout)
+	}
+
+	return nil
+}

--- a/version/version.go
+++ b/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-var Version = "0.8.0"
+var Version = "0.9.0"


### PR DESCRIPTION
Manage notification subscriptions across GitHub repositories.
At the moment only watch and unwatch options are available.