### PR TITLE
Fix password prompt on Windows

### DIFF
--- a/terminal/terminal.go
+++ b/terminal/terminal.go
@@ -14,7 +14,7 @@ import (
 // Source: https://gist.github.com/jlinoff/e8e26b4ffa38d379c7f1891fd174a6d0
 func PasswordPrompt(prompt ...string) (string, error) {
 	// Get the initial state of the terminal.
-	state, err := terminal.GetState(syscall.Stdin)
+	state, err := terminal.GetState(int(syscall.Stdin))
 	if err != nil {
 		return "", err
 	}
@@ -27,7 +27,7 @@ func PasswordPrompt(prompt ...string) (string, error) {
 	go func() {
 		select {
 		case <-sig:
-			_ = terminal.Restore(syscall.Stdin, state)
+			_ = terminal.Restore(int(syscall.Stdin), state)
 			fmt.Println()
 			os.Exit(1)
 		case <-quit:
@@ -41,7 +41,7 @@ func PasswordPrompt(prompt ...string) (string, error) {
 	}
 	fmt.Print(text)
 
-	password, err := terminal.ReadPassword(syscall.Stdin)
+	password, err := terminal.ReadPassword(int(syscall.Stdin))
 	fmt.Println()
 	if err != nil {
 		return "", err

--- a/version/version.go
+++ b/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-var Version = "0.9.1"
+var Version = "0.9.2"


### PR DESCRIPTION
```sh
GOOS=windows go build ./cmd/gh-find
# github.com/pmatseykanets/gh-tools/terminal
terminal/terminal.go:17:33: cannot use syscall.Stdin (type syscall.Handle) as type int in argument to terminal.GetState
terminal/terminal.go:30:24: cannot use syscall.Stdin (type syscall.Handle) as type int in argument to terminal.Restore
terminal/terminal.go:44:40: cannot use syscall.Stdin (type syscall.Handle) as type int in argument to terminal.ReadPassword
```

The `syscall.Stdin` has to be converted to `int`.

https://pkg.go.dev/syscall?GOOS=windows#pkg-variables

```go
var (
	Stdin  = getStdHandle(STD_INPUT_HANDLE)
	Stdout = getStdHandle(STD_OUTPUT_HANDLE)
	Stderr = getStdHandle(STD_ERROR_HANDLE)
)

func getStdHandle(h int) (fd Handle) {...}
```


vs 

https://pkg.go.dev/syscall?GOOS=linux#pkg-variables

```go
var (
	Stdin  = 0
	Stdout = 1
	Stderr = 2
)
```